### PR TITLE
Efficient parallel CPU utilization for solving

### DIFF
--- a/explore.go
+++ b/explore.go
@@ -1,0 +1,92 @@
+package main
+
+type exploreFunc func() try
+
+/*
+Explorer returns an exploreFunc with initial max start and a stride value.
+
+The nominal single case would be Explorer(0, 1), which returns a generator
+function that yields the sequence:
+
+    (0, 0)
+
+    (0, 1)
+    (1, 0)
+    (1, 1)
+
+    (0, 2)
+    (1, 2)
+    (2, 0)
+    (2, 1)
+    (2, 2)
+
+    (0, 3)
+    ...
+
+Multiple generator functions can be used to divide a sequence by adjusting the
+start offset and stride accordingly.  See splitExplore for a convenience
+function to help with this.
+*/
+func Explorer(start, stride int) exploreFunc {
+	max := start
+	i, j := 0, 0
+
+	return func() try {
+		if i >= max && j > max {
+			i, j = 0, 0
+			max += stride
+		}
+		if i <= max-1 {
+			ri := i
+			i++
+			return try{ri, max}
+		}
+		// known: j <= max
+		rj := j
+		j++
+		return try{max, rj}
+	}
+}
+
+// splitExplore will return a slice of exploreFuncs to split the sequence across
+// n generators. These generator functions do not share state and can be safely
+// used in parallel.
+//
+// Example: splitExplore(4) returns []exploreFunc{ Explorer(0,4), Explorer(1,4),
+// Explorer(2,4), Explorer(3,4)}.
+//
+//     f(0, 4)        f(1, 4)         f(2, 4)         f(3, 4)
+//     -------        -------         -------         -------
+//     {0 0}          {0 1}           {0 2}           {0 3}
+//                    {1 0}           {1 2}           {1 3}
+//     {0 4}          {1 1}           {2 0}           {2 3}
+//     {1 4}                          {2 1}           {3 0}
+//     {2 4}          {0 5}           {2 2}           {3 1}
+//     {3 4}          {1 5}                           {3 2}
+//     {4 0}          {2 5}           {0 6}           {3 3}
+//     {4 1}          {3 5}           {1 6}
+//     {4 2}          {4 5}           {2 6}           {0 7}
+//     {4 3}          {5 0}           {3 6}           {1 7}
+//     {4 4}          {5 1}           {4 6}           {2 7}
+//                    {5 2}           {5 6}           {3 7}
+//     {0 8}          {5 3}           {6 0}           {4 7}
+//     {1 8}          {5 4}           {6 1}           {5 7}
+//     {2 8}          {5 5}           {6 2}           {6 7}
+//     {3 8}                          {6 3}           {7 0}
+//     {4 8}          {0 9}           {6 4}           {7 1}
+//     {5 8}          {1 9}           {6 5}           {7 2}
+//     {6 8}          {2 9}           {6 6}           {7 3}
+//     {7 8}          {3 9}                           {7 4}
+//     {8 0}          {4 9}           {0 10}          {7 5}
+//     {8 1}          {5 9}           {1 10}          {7 6}
+//     ...            ...             ...             ...
+func splitExplore(n int) []exploreFunc {
+	if n <= 0 {
+		return []exploreFunc{}
+	}
+	res := make([]exploreFunc, n)
+	for i := 0; i < n; i++ {
+		res[i] = Explorer(i, n)
+	}
+	return res
+}

--- a/explore_test.go
+++ b/explore_test.go
@@ -1,0 +1,190 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestExplorer(t *testing.T) {
+	tests := []struct {
+		name    string
+		start   int
+		stride  int
+		samples int
+		want    []try
+	}{
+		{
+			name:   "uniform sequence",
+			start:  0,
+			stride: 1,
+			// samples: 9,
+			want: []try{
+				{0, 0},
+				// ---
+				{0, 1},
+				{1, 0},
+				{1, 1},
+				// ---
+				{0, 2},
+				{1, 2},
+				{2, 0},
+				{2, 1},
+				{2, 2},
+				// ---
+				{0, 3},
+				{1, 3},
+				{2, 3},
+				{3, 0},
+				{3, 1},
+				{3, 2},
+				{3, 3},
+				// ---
+				{0, 4},
+				{1, 4},
+				{2, 4},
+				{3, 4},
+				{4, 0},
+				{4, 1},
+				{4, 2},
+				{4, 3},
+				{4, 4},
+				// ---
+				{0, 5},
+				// ...
+			},
+		},
+		{
+			name:   "stride sequence",
+			start:  0,
+			stride: 2,
+			want: []try{
+				{0, 0},
+				// ---
+				{0, 2},
+				{1, 2},
+				{2, 0},
+				{2, 1},
+				{2, 2},
+				// ---
+				{0, 4},
+				{1, 4},
+				{2, 4},
+				{3, 4},
+				{4, 0},
+				{4, 1},
+				{4, 2},
+				{4, 3},
+				{4, 4},
+				// ---
+				{0, 6},
+				// ...
+			},
+		},
+		{
+			name:   "offset stride sequence",
+			start:  1,
+			stride: 2,
+			want: []try{
+				// ---
+				{0, 1},
+				{1, 0},
+				{1, 1},
+				// ---
+				{0, 3},
+				{1, 3},
+				{2, 3},
+				{3, 0},
+				{3, 1},
+				{3, 2},
+				{3, 3},
+				// ---
+				{0, 5},
+				// ...
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel() // run in parallel to validate thread safety
+
+			exploreFunc := Explorer(tt.start, tt.stride)
+			results := make([]try, 0, tt.samples)
+			for i := 0; i < len(tt.want); i++ {
+				results = append(results, exploreFunc())
+			}
+
+			if !reflect.DeepEqual(results, tt.want) {
+				t.Errorf("ExploreGen() = %v, want %v", results, tt.want)
+			}
+		})
+	}
+}
+
+func Test_splitExplore(t *testing.T) {
+	tests := []struct {
+		n    int
+		want []exploreFunc // equivalent exploreFunc that yields same sequence
+	}{
+		{1, []exploreFunc{Explorer(0, 1)}},
+		{2, []exploreFunc{Explorer(0, 2), Explorer(1, 2)}},
+		{3, []exploreFunc{Explorer(0, 3), Explorer(1, 3), Explorer(2, 3)}},
+		{-1, []exploreFunc{}}, // dont panic on negative ints
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("n=%d", tt.n), func(t *testing.T) {
+			got := splitExplore(tt.n)
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(splitExplore(%v)) = %d,  want %d", tt.n, len(got), len(tt.want))
+			}
+
+			for i := 0; i < len(got); i++ {
+				compareGenerators(t, got[i], tt.want[i], 10)
+			}
+		})
+	}
+}
+
+func compareGenerators(t *testing.T, f1, f2 exploreFunc, samples int) {
+	t.Helper()
+
+	r1 := make([]try, 0, samples)
+	r2 := make([]try, 0, samples)
+	for i := 0; i < samples; i++ {
+		r1 = append(r1, f1())
+		r2 = append(r2, f2())
+	}
+
+	t.Log("\nf1:", r1, "\nf2:", r2)
+	if !reflect.DeepEqual(r1, r2) {
+		t.Errorf("generated divergent seqs:\n\tf1: %v\n\tf2: %v", r1, r2)
+	}
+}
+
+func BenchmarkGeneratorFunc(b *testing.B) {
+	f := Explorer(0, 1)
+	for i := 0; i < b.N; i++ {
+		_ = f()
+	}
+}
+
+/*
+// Legacy boilerplate from when I was generating initial sample text (before
+// massaging it in asciiflow)
+
+func ExampleExploreGen() {
+	f1, f2, f3, f4 := ExploreGen(0, 4), ExploreGen(1, 4), ExploreGen(2, 4), ExploreGen(3, 4)
+
+    w := new(tabwriter.Writer)
+    // minwidth, tabwidth, padding, padchar, flags
+    w.Init(os.Stdout, 12, 8, 0, '\t', 0)
+    defer w.Flush()
+
+    fmt.Fprintf(w, "\n %s\t%s\t%s\t%s\t", "f(0,4)", "f(1,4)", "f(2,4)", "f(3,4)")
+    fmt.Fprintf(w, "\n %s\t%s\t%s\t%s\t", "------", "------", "------", "------")
+    for i := 0; i < 20; i++ {
+        fmt.Fprintf(w, "\n %v\t%v\t%v\t%v\t", f1(), f2(), f3(), f4())
+    }
+}
+*/


### PR DESCRIPTION
Replaces the single channel based explore iterator with generator functions that can be split for entirely isolated concurrent execution without overlap.

Prior to this, when running on multiple CPUs, the majority of the goroutines were starved on contention waiting for new data from the explore iterator:
![profile002](https://user-images.githubusercontent.com/40650/148651019-a02d8d14-97fd-4c24-a52a-cb3ccb20aa51.png)

After the change, the majority of the CPU time is back to hashing:
![profile003](https://user-images.githubusercontent.com/40650/148651055-9c6fbb49-fc7f-4cdc-815c-3bb9042eb724.png)

On my laptop (2018 MacBook Pro, intel 4 cores hyperthreaded), this results in a ~45% performance increase for the core solve .
```
name             old time/op    new time/op    delta
SolveParallel       658ns ± 1%     585ns ± 1%  -11.05%  (p=0.008 n=5+5)
SolveParallel-2     388ns ± 3%     301ns ± 2%  -22.40%  (p=0.008 n=5+5)
SolveParallel-4     250ns ± 8%     190ns ±10%  -24.02%  (p=0.008 n=5+5)
SolveParallel-8     283ns ± 2%     193ns ± 2%  -31.93%  (p=0.008 n=5+5)

name             old speed      new speed      delta
SolveParallel     527MB/s ± 1%   593MB/s ± 1%  +12.42%  (p=0.008 n=5+5)
SolveParallel-2   894MB/s ± 3%  1152MB/s ± 1%  +28.82%  (p=0.008 n=5+5)
SolveParallel-4  1.39GB/s ± 8%  1.83GB/s ±10%  +31.66%  (p=0.008 n=5+5)
SolveParallel-8  1.23GB/s ± 2%  1.80GB/s ± 2%  +46.93%  (p=0.008 n=5+5)
```

UPDATE: Testing the same on my partner's 2020 M1 MacBook Air reveals even more significant improvements.
```
name             old time/op    new time/op    delta
SolveParallel       266ns ± 0%     239ns ± 0%   -10.26%  (p=0.008 n=5+5)
SolveParallel-2     179ns ± 1%     123ns ± 0%   -31.06%  (p=0.008 n=5+5)
SolveParallel-4     140ns ± 3%      64ns ± 0%   -54.36%  (p=0.016 n=5+4)
SolveParallel-8     145ns ± 3%      45ns ± 0%   -69.02%  (p=0.008 n=5+5)

name             old speed      new speed      delta
SolveParallel    1.31GB/s ± 0%  1.45GB/s ± 0%   +11.44%  (p=0.008 n=5+5)
SolveParallel-2  1.94GB/s ± 1%  2.81GB/s ± 0%   +45.02%  (p=0.008 n=5+5)
SolveParallel-4  2.48GB/s ± 3%  5.44GB/s ± 0%  +119.04%  (p=0.008 n=5+5)
SolveParallel-8  2.40GB/s ± 3%  7.75GB/s ± 0%  +222.62%  (p=0.008 n=5+5)
```
(Also sheesh, I really need a new laptop.)